### PR TITLE
[driver] fix retry

### DIFF
--- a/src/lib/lumatone/midi/driver.ts
+++ b/src/lib/lumatone/midi/driver.ts
@@ -201,7 +201,7 @@ export class MidiDriver {
           const { sendQueue: q, ...s } = internalState
           const sendQueue = [commandAwaitingResponse, ...q]
           const retryTimeout = setTimeout(
-            this.#triggerRetry,
+            this.#triggerRetry.bind(this),
             BUSY_RETRY_TIMEOUT_MS
           )
           return {


### PR DESCRIPTION
Because the `#triggerRetry` function is invoked using `setTimeout`, `this` will be `undefined`, leading to the error mentioned in #14. See https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#the_this_problem for reference. Binding it to `this` solved the problem.

Fixes #14.