### PR TITLE
feat: driver per board

### DIFF
--- a/src/lib/lumatone/midi/controller.ts
+++ b/src/lib/lumatone/midi/controller.ts
@@ -8,14 +8,17 @@ import tinycolor from 'tinycolor2'
  * Public API for interacting with lumatone device.
  */
 export class LumatoneController {
-  #driver: MidiDriver
+  #driver: MidiDriver[]
 
   constructor(device: MidiDevice) {
-    this.#driver = new MidiDriver(device)
+    this.#driver = Array.from(
+      { length: 5 },
+      (_, i) => new MidiDriver(device, i)
+    )
   }
 
-  get driver(): MidiDriver {
-    return this.#driver
+  driver(boardIndex: number): MidiDriver {
+    return this.#driver[boardIndex]
   }
 
   async sendDeviceConfig(config: DeviceConfig): Promise<void> {
@@ -54,7 +57,7 @@ export class LumatoneController {
       b
     )
 
-    this.#driver.submitCommand(setFunctions)
-    this.#driver.submitCommand(setLights)
+    this.#driver[boardIndex].submitCommand(setFunctions)
+    this.#driver[boardIndex].submitCommand(setLights)
   }
 }


### PR DESCRIPTION
Changing all lights and waiting for an ack for each individual message is a somewhat slow process. We can leverage the fact that ack messages include the boardIndex to deal with all boards in parallel.

This PR adds a `boardIndex` property to the `MidiDriver`, and creates a separate driver for each board. Each driver only handles messages for one board.

I've also lowered the retry timeout to the point where it did not trigger any additional retries, which is a lot lower than the original value.

It's hard to time the process end to end due to the asynchronous nature of the process, but from testing locally I can confidently say that this is a lot faster.